### PR TITLE
Replace rust-crypto with RustCrypto crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,12 @@ reqwest = "0.11"
 base64 = "0.13"
 md5 = "0.7"
 crc = "2.0"
-rust-crypto = "0.2"
 rustc_version_runtime = "0.2.0"
 
 quick-xml = { version = "0.22", features = [ "serialize" ] }
+sha-1 = "0.9.8"
+sha2 = "0.9.8"
+hmac = "0.11.0"
 
 [dev-dependencies]
 pretty_env_logger = "0.4"


### PR DESCRIPTION
`rust-crypto` is unmaintained, https://github.com/RustCrypto is the
replacement.